### PR TITLE
JS Binary Trees : Moved from Closure to Class with V-Tables

### DIFF
--- a/binarytrees/binarytrees.js
+++ b/binarytrees/binarytrees.js
@@ -6,12 +6,15 @@
    sequential by Isaac Gouy
 */
 
-function TreeNode(item, left, right) {
-  this.item = item;
-  this.left = left;
-  this.right = right;
 
-  this.check = function() {
+class TreeNode {
+  constructor(item, left, right) {
+    this.item = item;
+    this.left = left;
+    this.right = right;
+  }
+
+  check () {
     if (this.left === null) return this.item;
     return this.item + this.left.check() - this.right.check();
   }
@@ -52,4 +55,3 @@ function work(iterations, depth) {
 }
 
 mainThread();
-


### PR DESCRIPTION
As stated in #1 and because a mistake fixed on an implementation should be fixed in another one  : 
Moved from Closure to Class as classes uses V-Tables.

I could have moved to a more C fix like I did with Lua but JS conventions and general code quality rules advises to move to class when possible.


With closures : `time(6.451)`

With class : `time(3.091)`